### PR TITLE
Remove misleading `return` statements from `uninstall` function

### DIFF
--- a/api.js
+++ b/api.js
@@ -19,10 +19,10 @@ exports.install = () => {
 exports.uninstall = () => {
   if (process.type === 'renderer') {
     console.log(`Uninstalling Devtron from ${__dirname}`)
-    return electron.remote.BrowserWindow.removeDevToolsExtension('devtron')
+    electron.remote.BrowserWindow.removeDevToolsExtension('devtron')
   } else if (process.type === 'browser') {
     console.log(`Uninstalling Devtron from ${__dirname}`)
-    return electron.BrowserWindow.removeDevToolsExtension('devtron')
+    electron.BrowserWindow.removeDevToolsExtension('devtron')
   } else {
     throw new Error('Devtron can only be uninstalled from an Electron process.')
   }


### PR DESCRIPTION
BrowserWindow.removeDevToolsExtensions() doesn't actually return
anything.